### PR TITLE
PR template: fix checklist rendering

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -16,11 +16,11 @@ _Additional work required in the future on top of this_
 
 ## Checklist
 ### Author
-- [] I have self-reviewed the code
-- [] I have added relevant tests (shared code, cross user sharing, complex logic, etc)
-- [] All APIs have permission checks
-- [] All APIs are backwards compatible
+- [ ] I have self-reviewed the code
+- [ ] I have added relevant tests (shared code, cross user sharing, complex logic, etc)
+- [ ] All APIs have permission checks
+- [ ] All APIs are backwards compatible
 
 ### Reviewer
-- [] All APIs have permission checks
-- [] All APIs are backwards compatible
+- [ ] All APIs have permission checks
+- [ ] All APIs are backwards compatible


### PR DESCRIPTION
there was a space missing in `- []` which did not render them as checkboxes in the PR description